### PR TITLE
Use custom axios instance instead of the global one

### DIFF
--- a/lib/functions.js
+++ b/lib/functions.js
@@ -1,13 +1,18 @@
-const curl = require('axios')
+const axios = require('axios')
 const opts = require('./opts')
 var _emitter = null
+
+const curl = axios.create({
+    baseURL: opts.url,
+    headers: {
+        'Content-Type': 'application/json'
+    }
+})
 
 module.exports = {
 
     initialize: function (config) {
         console.log('------initialize',config)
-        curl.defaults.baseURL = opts.url
-        curl.defaults.headers.post['Content-Type'] = 'application/json'
         curl.defaults.headers.common['x-api-key'] = config.apikey;
         delete curl.defaults.headers.common["Authorization"];
         _emitter = config._emitter


### PR DESCRIPTION
I encountered the problem where this library adds headers (x-api-key) to queries. This can cause a CORS problem when the server does not allow these headers.